### PR TITLE
[GAT-17]: User actions log

### DIFF
--- a/build/tests/behat/behat.yml
+++ b/build/tests/behat/behat.yml
@@ -55,6 +55,10 @@ drupal:
           drupal_root: ../../docroot
         drush:
           root: ../../docroot
+        selectors:
+          message_selector: '.messages'
+          error_message_selector: '.messages.error'
+          success_message_selector: '.messages.status'
 
 
 imports:

--- a/build/tests/behat/behat.yml
+++ b/build/tests/behat/behat.yml
@@ -56,8 +56,6 @@ drupal:
         drush:
           root: ../../docroot
         selectors:
-          message_selector: '.messages'
-          error_message_selector: '.messages.error'
           success_message_selector: '.messages.status'
 
 

--- a/build/tests/behat/bootstrap/FeatureContext.php
+++ b/build/tests/behat/bootstrap/FeatureContext.php
@@ -71,11 +71,11 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
     // Check if a user with this role is already logged in.
     if (!$this->loggedInWithRole($role)) {
       // Create user (and project)
-      $user = (object) [
+      $user = (object) array(
         'name' => !empty($username) ? $username : $this->getRandom()->name(8),
         'pass' => $this->getRandom()->name(16),
         'role' => $role,
-      ];
+      );
       $user->mail = "{$user->name}@example.com";
 
       $this->userCreate($user);

--- a/build/tests/behat/bootstrap/FeatureContext.php
+++ b/build/tests/behat/bootstrap/FeatureContext.php
@@ -108,7 +108,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   /**
    * Creates and authenticates a user with the given permission.
    *
-   * @Given /^I am logged in as a user (?:|named )(?:|"(?P<username>[^"]*)" )with the "(?P<permissions>[^"]*)" permission and don't need a password change$/
+   * @Given /^I am logged in as a user (?:|named "(?P<username>[^"]*)" )with the "(?P<permissions>[^"]*)" permission and don't need a password change$/
    */
   public function assertAuthenticatedWithPermission($username, $permissions) {
     // Create user.

--- a/build/tests/behat/bootstrap/FeatureContext.php
+++ b/build/tests/behat/bootstrap/FeatureContext.php
@@ -108,7 +108,7 @@ class FeatureContext extends RawDrupalContext implements SnippetAcceptingContext
   /**
    * Creates and authenticates a user with the given permission.
    *
-   * @Given /^I am logged in as a user (?:|named "(?P<username>[^"]*)" )with the "(?P<permissions>[^"]*)" permission and don't need a password change$/
+   * @Given /^I am logged in as a user (?:|named )(?:|"(?P<username>[^"]*)" )with the "(?P<permissions>[^"]*)" permission and don't need a password change$/
    */
   public function assertAuthenticatedWithPermission($username, $permissions) {
     // Create user.

--- a/build/tests/behat/features/user-actions.feature
+++ b/build/tests/behat/features/user-actions.feature
@@ -1,0 +1,64 @@
+Feature: User Actions
+
+  Ensure the user actions are being logged
+
+  @api @javascript @drupal
+  Scenario: Perform typical user account actions and verify that they are logged.
+    Given I am logged in as a user "roman" with the "administer users" permission and don't need a password change
+    When I am on "/admin/people/create"
+    Then I fill in the following:
+      | name        | MyUser             |
+      | mail        | myuser@example.com |
+      | pass[pass1] | /123456789A        |
+      | pass[pass2] | /123456789A        |
+    And I press "Create new account"
+    Then I should see the success message containing "Created a new user account"
+    And I logout
+    Given I am logged in as a user "barbun" with the "administer users" permission and don't need a password change
+    And I visit the user edit page for "MyUser"
+    And I press "Cancel account"
+    And I select the radio button "Disable the account and unpublish its content."
+    And I press "Cancel account"
+    Then I should see the success message containing "MyUser has been disabled."
+    And I logout
+    Given a user named "MyUser" is deleted
+    When I am logged in as a user with the "Site editor" role that doesn't force password change
+    And I am on "/admin/reports/user-actions"
+    Then I should see "login" in a table row with the text "roman"
+    And I should see "logout" in a table row with the text "roman"
+    And I should see "login" in a table row with the text "barbun"
+    And I should see "logout" in a table row with the text "barbun"
+    And I should see "insert" in a table row with the text "User: MyUser"
+    And I should see "update" in a table row with the text "User: MyUser"
+
+  @api @javascript @drupal
+  Scenario: Perform typical node actions and verify that they are logged.
+    Given I am logged in as a user named "danielle" with the "Content editor" role that doesn't force password change
+    When I go to "/node/add/news-article"
+    Then I should see "Create News Article"
+    And I enter "govCMS News" for "Title"
+    Given the iframe in element "cke_edit-body-und-0-value" has id "body-wysiwyg"
+    And I fill in "govCMS is the best!" in WYSIWYG editor "body-wysiwyg"
+    And press "Save"
+    Then I should see "News Article govCMS News has been created"
+    Then I logout
+    Given I am logged in as a user named "jodie" with the "Content approver" role that doesn't force password change
+    When I go to "/news-media/news/govcms-news"
+    Then I click "Edit draft"
+    And I enter "govCMS Updates" for "Title"
+    And press "Save"
+    Then I should see "News Article govCMS Updates has been updated."
+    Then I logout
+    Given I am logged in as a user named "janette" with the "administrator" role that doesn't force password change
+    When I go to "/news-media/news/govcms-updates"
+    Then I click "Edit draft"
+    And I press "Delete"
+    Then I should see "Are you sure you want to delete govCMS Updates?"
+    And I press "Delete"
+    Then I should see the success message "News Article govCMS Updates has been deleted."
+    And I logout
+    Given I am logged in as a user with the "Site editor" role that doesn't force password change
+    And I am on "/admin/reports/user-actions"
+    Then I should see "insert" in a table row with the text "news_article: govCMS News"
+    And I should see "update" in a table row with the text "news_article: govCMS Updates"
+    And I should see "delete" in a table row with the text "news_article: govCMS Updates"

--- a/build/tests/behat/features/user-actions.feature
+++ b/build/tests/behat/features/user-actions.feature
@@ -21,15 +21,15 @@ Feature: User Actions
     And I press "Cancel account"
     Then I should see the success message containing "MyUser has been disabled."
     And I logout
-    Given a user named "MyUser" is deleted
-    When I am logged in as a user with the "Site editor" role that doesn't force password change
+    When a user named "MyUser" is deleted
+    Given I am logged in as a user with the "Site editor" role that doesn't force password change
     And I am on "/admin/reports/user-actions"
-    Then I should see "login" in a table row with the text "roman"
-    And I should see "logout" in a table row with the text "roman"
-    And I should see "login" in a table row with the text "barbun"
-    And I should see "logout" in a table row with the text "barbun"
-    And I should see "insert" in a table row with the text "User: MyUser"
-    And I should see "update" in a table row with the text "User: MyUser"
+    Then I should see "login" in a table row containing the text "roman"
+    And I should see "logout" in a table row containing the text "roman"
+    And I should see "login" in a table row containing the text "barbun"
+    And I should see "logout" in a table row containing the text "barbun"
+    And I should see "insert" in a table row containing the text "User: MyUser"
+    And I should see "update" in a table row containing the text "User: MyUser"
 
   @api @javascript @drupal
   Scenario: Perform typical node actions and verify that they are logged.
@@ -59,6 +59,6 @@ Feature: User Actions
     And I logout
     Given I am logged in as a user with the "Site editor" role that doesn't force password change
     And I am on "/admin/reports/user-actions"
-    Then I should see "insert" in a table row with the text "news_article: govCMS News"
-    And I should see "update" in a table row with the text "news_article: govCMS Updates"
-    And I should see "delete" in a table row with the text "news_article: govCMS Updates"
+    Then I should see "insert" in a table row containing the text "news_article: govCMS News"
+    And I should see "update" in a table row containing the text "news_article: govCMS Updates"
+    And I should see "delete" in a table row containing the text "news_article: govCMS Updates"


### PR DESCRIPTION
* Added success/error messages selectors to Drupal behat profile.
* Brought in a custom version of getTableRow function that selects only table rows with specific text.
* Improved authentication by role function, used default function from Drupal Context and added force password change cancellation bit.
* Added a definition for "Given a user is deleted" to clean up a manually created users during the tests. This function is helpful because govCMS blocks deletion of users for security reasons.
* Added a definition for "And I take a screenshot named" for debugging purposes.
* Added a step definition for "And I should see :text in a table row with :text" to search for a table row with specific text that also contains a matching text.
