### PR TITLE
[GAT-15] One more fix to the Iconomist tests.

### DIFF
--- a/modules/custom/iconomist/iconomist.class.php
+++ b/modules/custom/iconomist/iconomist.class.php
@@ -53,10 +53,11 @@ class Iconomist {
     $form_state['storage']['iconomist_num_icons'] = max($form_state['storage']['iconomist_num_icons'], 0);
 
     // Display toggles.
+    $default_value = theme_get_setting('toggle_iconomist', $theme);
     $form['theme_settings']['toggle_iconomist'] = array(
       '#type' => 'checkbox',
       '#title' => t('Iconomist Icons'),
-      '#default_value' => theme_get_setting('toggle_iconomist', $theme) ? theme_get_setting('toggle_iconomist', $theme) : TRUE,
+      '#default_value' =>  is_null($default_value) ? TRUE : $default_value,
     );
 
     // Iconomist fieldset.


### PR DESCRIPTION
The test was totally broken - I don't know how it passed my testing, Jenkins and CR. The possible values are NULL (no theme setting), TRUE and FALSE. We want the TRUE or FALSE to be kept and NULL to be replaced by TRUE (the overarching default for the value).

Signed-off-by: Nigel Cunningham <nigel@salsadigital.com.au>